### PR TITLE
Make backend-mmap optional again

### DIFF
--- a/vhost/CHANGELOG.md
+++ b/vhost/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 ### Changed
+- `backend-mmap` is now optional and automatically enabled when the `xen`
+  feature is selected. The `from_guest_region` helper remains available but
+  is compiled only with the `backend-mmap` feature.
 ### Deprecated
 ### Fixed
 - [[#304]](https://github.com/rust-vmm/vhost/pull/304) Fix building docs.

--- a/vhost/Cargo.toml
+++ b/vhost/Cargo.toml
@@ -23,7 +23,8 @@ vhost-net = ["vhost-kern"]
 vhost-user = []
 vhost-user-frontend = ["vhost-user"]
 vhost-user-backend = ["vhost-user"]
-xen = ["vm-memory/xen"]
+xen = ["vm-memory/xen", "backend-mmap"]
+backend-mmap = ["vm-memory/backend-mmap"]
 postcopy = []
 
 [dependencies]
@@ -32,8 +33,9 @@ libc = "0.2.39"
 uuid = { version = "1.11.0", features=["v4", "fast-rng"] }
 
 vmm-sys-util = { workspace = true }
-vm-memory = { workspace = true, features=["backend-mmap"] }
+vm-memory = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.2.0"
 serial_test = "3.0"
+vm-memory = { workspace = true, features=["backend-mmap"] }

--- a/vhost/src/backend.rs
+++ b/vhost/src/backend.rs
@@ -10,16 +10,20 @@
 //! Common traits and structs for vhost-kern and vhost-user backend drivers.
 
 use std::cell::RefCell;
-use std::os::unix::io::AsRawFd;
 use std::os::unix::io::RawFd;
+#[cfg(feature = "backend-mmap")]
+use std::os::unix::io::AsRawFd;
 use std::sync::RwLock;
 
+#[cfg(feature = "backend-mmap")]
 use vm_memory::{bitmap::Bitmap, Address, GuestMemoryRegion, GuestRegionMmap};
 use vmm_sys_util::eventfd::EventFd;
 
 #[cfg(feature = "vhost-user")]
 use super::vhost_user::message::{VhostUserMemoryRegion, VhostUserSingleMemoryRegion};
-use super::{Error, Result};
+#[cfg(feature = "backend-mmap")]
+use super::Error;
+use super::Result;
 
 /// Maximum number of memory regions supported.
 pub const VHOST_MAX_MEMORY_REGIONS: usize = 255;
@@ -88,6 +92,7 @@ pub struct VhostUserMemoryRegionInfo {
 
 impl VhostUserMemoryRegionInfo {
     /// Creates Self from GuestRegionMmap.
+    #[cfg(feature = "backend-mmap")]
     pub fn from_guest_region<B: Bitmap>(region: &GuestRegionMmap<B>) -> Result<Self> {
         let file_offset = region
             .file_offset()


### PR DESCRIPTION
## Summary
- expose `backend-mmap` as an optional feature and let `xen` enable it
- remove the unconditional `backend-mmap` dependency on `vm-memory`
- keep `from_guest_region` but compile it (and related imports) only with the feature
- note the change in the changelog

## Testing
- `cargo test --workspace --no-fail-fast`
- `cargo test --workspace --features xen --no-fail-fast`
- `cargo test --workspace --features 'xen backend-mmap' --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_686ac52827c48322840d68e40b244212